### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Things you may want to cover:
 * has_many comments
 * has_many likes
 
+## Credit_cardsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|references|foreign_key: true|
+|customer_id|string|null: false|
+|card_id|string|null: false|
+
+
 
 ## Itemsテーブル
 |Column|Type|Options|
@@ -61,7 +69,8 @@ Things you may want to cover:
 |brand_id|references|foreign_key: true|
 |user_id|references|foreign_key: true, null: false|
 |category_id|referemces|foreign_key: ture|
-|status|string|null: false|
+|seller_id|references|foreign_key: true|
+|buyer_id|references|foreign_key: true|
 
 ### Association
 * belongs_to user


### PR DESCRIPTION
# WHAT
・Itemsテーブルに「seller_id」「buyer_id」を追加
・Credit_cardテーブルを新たに作成

# WHY
・商品の取引の際に購入者と出品者の紐付けが必要になるため。
・クレジットカードテーブルを作成すると危険とのことで一旦作成するのをやめていたが、pay.jpのトークンを保存してユーザーに紐付けることで登録機能の実装が可能とのこと。