### PR TITLE
商品削除機能実装

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -803,9 +803,24 @@
               }       
             }
             .ItemEditBtn4 {
+              display: flex;
+              flex-direction: column;
               text-align: center;
               margin: 35px 0;
               &__editbtn4 {
+                display: inline-block;
+                margin: 10px auto;
+                width: 60%;
+                text-decoration: none;
+                background-color:#3CCACE;
+                border-radius: 4px;
+                padding: 10px 20px;
+                color: white;
+              }
+              &__deletebtn4 {
+                display: inline-block;
+                margin: 10px auto;
+                width: 60%;
                 text-decoration: none;
                 background-color: tomato;
                 border-radius: 4px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,6 +36,12 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to root_path
+  end
+
   private
   
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,11 @@ class ItemsController < ApplicationController
 
   def destroy
     @item = Item.find(params[:id])
-    @item.destroy
-    redirect_to root_path
+    if @item.destroy
+       redirect_to root_path
+    else
+      render :show
+    end
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -77,6 +77,7 @@
                   %td 1-2日で発送
           .ItemEditBtn4
             = link_to '商品情報を編集する', edit_item_path(params[:id]), class: "ItemEditBtn4__editbtn4"
+            = link_to '商品情報を削除する', item_path(params[:id]), method: "DELETE", class: "ItemEditBtn4__deletebtn4"
           .optionalArea2
             %ul.like2
               %li.likeBtn2


### PR DESCRIPTION
# WHAT
・商品詳細ページに削除ボタン設置（User機能が未完成のため出品ユーザーにのみ表示させる実装は未）
・出品済み商品とそれに紐付いた画像の削除機能実装
# WHY
一度出品した商品を削除できることで、出品者による商品の管理をより柔軟なものにできるから。