### PR TITLE
TOPページのlink_toタグ修正

### DIFF
--- a/app/assets/stylesheets/modules/_items.scss
+++ b/app/assets/stylesheets/modules/_items.scss
@@ -616,6 +616,8 @@
         .productLists1{
           width: 780px;
           margin: 26px auto;
+          margin-bottom: 0;
+          padding-bottom: 26px;
           display: flex;
           justify-content: space-around;
             .productList1{

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -132,7 +132,8 @@
         - @mens_items.each do |item|
           .productList1
             .productList--img1
-              = image_tag item.images[0].src.url, width: "220px", height:"150px"
+              = link_to item_path(item.id) do
+                = image_tag item.images[0].src.url, width: "220px", height:"150px"
             .productList--body1
               .name1
                 %span= item.name
@@ -156,8 +157,7 @@
       .productLists1
         - @chanel_brands.each do |item|
           .productList1
-            -# あとで、item_path(params[:id])に変える
-            = link_to '/items/15' do
+            = link_to item_path(item.id) do
               .productList--img1
                 = image_tag item.images[0].src.url, width: "220px", height:"150px"
               .productList--body1


### PR DESCRIPTION
# WHAT
TOPページから商品詳細に遷移するlink_toタグの記述を修正。また、ピックアップブランド一覧表示下部の余白を修正。
# WHY
TOPページにおける一覧表示画像から詳細画面に遷移できるようにすることでユーザーにとって分かりやすいページ遷移を実現できるから。