### PR TITLE
出品者idと購入者idを作成

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,8 @@ class ItemsController < ApplicationController
 
   #商品一覧表示
   def index
-    @mens_items = Item.where(category_id:"2")
-    @chanel_brands = Item.where(brand:"シャネル")
+    @mens_items = Item.where(category_id:"2").includes(:user)
+    @chanel_brands = Item.where(brand:"シャネル").includes(:user)
   end
 
 
@@ -21,7 +21,6 @@ class ItemsController < ApplicationController
   end
 
   def create
-    # ログインユーザーのIDを自動保存する処理が必要（ユーザー機能ができてから）
     @item = Item.new(item_params)
     if @item.save
       redirect_to root_path
@@ -61,12 +60,7 @@ class ItemsController < ApplicationController
   private
   
   def item_params
-
-    params.require(:item).permit(:name, :text, :condition_id, :category_id, :burden_id, :area_id, :shipping_date_id, :price, :brand, images_attributes: [:src])
-
-
-    params.require(:item).permit(:name, :text, :condition_id, :category_id, :burden_id, :area_id, :shipping_date_id, :price, :brand, images_attributes: [:src, :_destroy, :id])
-
+    params.require(:item).permit(:name, :text, :condition_id, :category_id, :burden_id, :area_id, :shipping_date_id, :price, :brand, images_attributes: [:src, :_destroy, :id]).merge(user_id: current_user.id)
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,7 @@ class Item < ApplicationRecord
   
 
   # あとでアソシエーション記述する（残り、ユーザーモデルとの紐付け。）
+  belongs_to :user
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   validates :nickname, :family_name, :first_name, :family_name_furigana, :first_name_furigana, presence: true
   validates :password, presence: true, format: { with: VALID_PASSWORD_REGEX }
   has_one :address
+  has_many :items, dependent: :destroy
   end
 
 

--- a/db/migrate/20201012102341_change_column_to_items.rb
+++ b/db/migrate/20201012102341_change_column_to_items.rb
@@ -1,0 +1,6 @@
+class ChangeColumnToItems < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :items, :user, foreign_key: true
+    add_column :items, :buyer_id, :integer 
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_11_104245) do
+ActiveRecord::Schema.define(version: 2020_10_12_102341) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "prefecture"
@@ -51,6 +51,9 @@ ActiveRecord::Schema.define(version: 2020_10_11_104245) do
     t.integer "area_id"
     t.integer "shipping_date_id"
     t.string "brand"
+    t.bigint "user_id"
+    t.integer "buyer_id"
+    t.index ["user_id"], name: "index_items_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -72,4 +75,5 @@ ActiveRecord::Schema.define(version: 2020_10_11_104245) do
 
   add_foreign_key "addresses", "users"
   add_foreign_key "images", "items"
+  add_foreign_key "items", "users"
 end


### PR DESCRIPTION
# WHAT
・itemsテーブルにuser_id（出品者）とbuyer_id（購入者）カラムを作成。
・itemモデルとuserモデルの関連付けのためアソシエーション記述。
・itemsコントローラーのcreateアクションにてuser_id（出品者として）にcurrent_userを保存させるよう、ストロングパラメーターに追記
・itemsコントローラーのindexアクションで呼び出している複数のitemモデルに対しN+1問題対策用のコードを追記。
# WHY
商品出品の際に自動的にログインユーザーとの紐付けをすることにより、商品詳細ページ内のボタン表示などをログインユーザーごとに適切な表示に切り替えることができる。また、各商品に「出品者」と「購入者」の情報を持たせることによって商品の状態（出品中や売却済みなど）を管理することができる。